### PR TITLE
Update Uri.Extensions.cs

### DIFF
--- a/NetBIX.oBIX.PortableClient/Extensions/Uri.Extensions.cs
+++ b/NetBIX.oBIX.PortableClient/Extensions/Uri.Extensions.cs
@@ -14,7 +14,7 @@ namespace NetBIX.oBIX.Client.Extensions {
             } else if (uriString.StartsWith("/")) {
                 return new Uri(uri, uriString);
              } else {
-                 return new Uri(Url.Combine(uri.ToString(), uriString.Split('/')));
+                 return new Uri(Url.Combine(uri.ToString(), uriString));
              }
         }
 


### PR DESCRIPTION
Latest version of Flurl will only take strings for the combine, not a array.  No longer need to split it.